### PR TITLE
Revert back to conda build 1.20.0 for all

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ install:
     # Workaround for Python 3.4 and x64 bug in latest conda-build.
     # FIXME: Remove once there is a release that fixes the upstream issue
     # ( https://github.com/conda/conda-build/issues/895 ).
-    - cmd: conda install conda-build=1.20.3 --yes
+    - cmd: conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off


### PR DESCRIPTION
The bug with python 3.4 and conda build > 1.20.0 still exist. So revert back to this version.