### PR TITLE
Remove navigator app entry

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   entry_points:
     - xonsh = xonsh.main:main
   skip: True  # [py2k]
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,11 +38,6 @@ test:
     - USER=test xonsh -h  # [unix]
     - xonsh -h  # [win]
 
-app:
-  entry: xonsh
-  icon: xonsh.png
-  summary: Python-powered, cross-platform, Unix-gazing shell
-  type: desk
 
 about:
   home: http://xon.sh


### PR DESCRIPTION
This will remove the `app:` entry, so xonsh doesn't show up in Anaconda Navigator. 