### PR TITLE
Add PTK<2 as requirement

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,24 +43,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   entry_points:
     - xonsh = xonsh.main:main
   skip: True  # [py2k]
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -25,7 +25,7 @@ requirements:
   run:
     - python
     - ply
-    - prompt_toolkit
+    - prompt_toolkit <2.0
     - pygments
     - setproctitle
 


### PR DESCRIPTION
This is necessary if PTK2 comes out before xonsh is made compatible. 

But I could be afraid that conda would just take an older version of xonsh where we didn't specify this requirement explicitly. 

