### PR TITLE
Remove ply dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,17 +15,15 @@ build:
     - xonsh = xonsh.main:main
     - xonsh-cat = xonsh.xoreutils.cat:cat_main
   skip: True  # [py2k]
-  number: 0
+  number: 1
 
 requirements:
   build:
     - python
-    - ply
     - setuptools
     - jupyter_client
   run:
     - python
-    - ply
     - prompt_toolkit
     - pygments >=2.2
     - setproctitle


### PR DESCRIPTION
Xonsh now uses its own vended version of ply. Since ply is no longer distributed as an installable package.
