### PR TITLE
Add import of __amalgam__

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,55 +1,57 @@
+{% set name = "xonsh" %}
 {% set version = "0.9.18" %}
+{% set sha256 = "723a548fe2cc0d0db8fe90c121b2c0d8a541f34956ea446e8a7ef2c83fcf99c0" %}
 
 package:
-  name: xonsh
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: xonsh-{{ version }}.tar.gz
-  url: https://github.com/xonsh/xonsh/releases/download/{{ version }}/xonsh-{{ version }}.tar.gz
-  sha256: 39b864991ac6eca7bd484fe1f9b2932d44ceb2b2a0deaa3679200e43ddddfa4e
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/xonsh/xonsh/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt  # [not win]
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"  # [not win]
   entry_points:
     - xonsh = xonsh.main:main
     - xonsh-cat = xonsh.xoreutils.cat:cat_main
   skip: true  # [py2k]
-  number: 0
+  number: 1
 
 requirements:
   host:
     - python
-    - setuptools
+    - pip
     - jupyter_client
   run:
     - python
     - prompt_toolkit
     - pygments >=2.2
-    - setproctitle
     - pyreadline  # [win]
+    - setproctitle
 
 test:
   requires:
     - pytest
   imports:
     - xonsh
+    - xonsh.__amalgam__
   commands:
     - USER=test xonsh -h  # [unix]
     - xonsh -h  # [win]
 
 about:
   home: http://xon.sh
-  license: BSD 2-Clause
-  license_family: BSD
+  license: BSD-2-Clause
   license_file: license
   summary: Python-powered, cross-platform, Unix-gazing shell
   description: |
     Xonsh is a Python-powered, cross-platform, Unix-gazing shell shell language
-    and command prompt. The language is a superset of Python 3.4+ with additional
-    shell primitives that you are used to from Bash and IPython. It works on all
-    major systems including Linux, Mac OSX, and Windows. Xonsh is meant for the
-    daily use of experts and novices alike.
+    and command prompt. The language is a superset of Python 3.4+ with
+    additional shell primitives that you are used to from Bash and IPython. It
+    works on all major systems including Linux, Mac OSX, and Windows. Xonsh is
+    meant for the daily use of experts and novices alike.
   doc_url: http://xon.sh
   dev_url: https://github.com/xonsh/xonsh
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xonsh" %}
 {% set version = "0.9.18" %}
-{% set sha256 = "723a548fe2cc0d0db8fe90c121b2c0d8a541f34956ea446e8a7ef2c83fcf99c0" %}
+{% set sha256 = "39b864991ac6eca7bd484fe1f9b2932d44ceb2b2a0deaa3679200e43ddddfa4e" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
 {% set name = "xonsh" %}
 {% set version = "0.9.18" %}
-{% set sha256 = "39b864991ac6eca7bd484fe1f9b2932d44ceb2b2a0deaa3679200e43ddddfa4e" %}
+{% set sha256 = "723a548fe2cc0d0db8fe90c121b2c0d8a541f34956ea446e8a7ef2c83fcf99c0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/xonsh/xonsh/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
GitHub sources do not have the `__amalgam__.py` file. The plan is to have it run and fail. Then another commit will be to use the sources from PyPI where the file presents.

I did some formatting updates (parametrization of the `name`, `sha256`; sorting dependencies, <80 symbols in width for the description, SPDX license compliance, ...), hopefully it's fine with the maintainers.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
