### PR TITLE
Update meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
     - xonsh = xonsh.main:main
     - xonsh-cat = xonsh.xoreutils.cat:cat_main
   skip: true  # [py2k]
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -30,7 +30,6 @@ requirements:
     - prompt_toolkit
     - pygments >=2.2
     - setproctitle
-    - pyreadline  # [win]
     - conda-suggest
 
 test:


### PR DESCRIPTION
The pyreadline library is essentially dead on windows and triggers lots of warnings.

Some deprecation warnings will even cause a hard crash on Python 3.10. 

The readline backend on windows doesn't work well anyway so I think the conda packages shouldn't install it by default. Users can still install pyreadline manually, if they need it. 
